### PR TITLE
Remove changer to set moctoken to commission address, now is deployed…

### DIFF
--- a/migrations/utils.js
+++ b/migrations/utils.js
@@ -487,7 +487,7 @@ const makeUtils = async (artifacts, networkName, config, owner, deployer) => {
 
     let mocTokenCommissionsAddress = owner;
     if (config.mocTokenCommissionsAddress !== '') {
-      ({ mocTokenCommissionsAddress } = config.mocTokenCommissionsAddress);
+      mocTokenCommissionsAddress  = config.mocTokenCommissionsAddress;
     }
 
     await commissionSplitter.initialize(

--- a/scripts/deploy/upgrade_v0.1.12/10_batch_changer.js
+++ b/scripts/deploy/upgrade_v0.1.12/10_batch_changer.js
@@ -165,24 +165,6 @@ module.exports = async callback => {
     targets.push(moCSettlementAddress);
     datas.push(moCSettlement.contract.methods.fixTasksPointer().encodeABI());
 
-    console.log('Prepare CommissionSplitter');
-    const commissionSplitterAddress = config.proxyAddresses.CommissionSplitter;
-    const commissionSplitter = await CommissionSplitter.at(commissionSplitterAddress);
-    // setMocToken
-    targets.push(commissionSplitterAddress);
-    datas.push(
-      commissionSplitter.contract.methods
-        .setMocToken(config.implementationAddresses.MoCToken)
-        .encodeABI()
-    );
-    // setMocTokenCommissionAddress
-    targets.push(commissionSplitterAddress);
-    datas.push(
-      commissionSplitter.contract.methods
-        .setMocTokenCommissionAddress(config.valuesToAssign.mocTokenCommissionsAddress)
-        .encodeABI()
-    );
-
     console.log('Prepare MoCInrate');
     const moCInrateAddress = config.proxyAddresses.MoCInrate;
     const moCInrate = await MoCInrate.at(moCInrateAddress);
@@ -200,7 +182,7 @@ module.exports = async callback => {
     targets.push(moCInrateAddress);
     datas.push(
       moCInrate.contract.methods
-        .setCommissionsAddress(config.implementationAddresses.CommissionSplitter)
+        .setCommissionsAddress(config.proxyAddresses.CommissionSplitter)
         .encodeABI()
     );
 

--- a/scripts/deploy/upgrade_v0.1.12/11_verification_changer.js
+++ b/scripts/deploy/upgrade_v0.1.12/11_verification_changer.js
@@ -254,55 +254,10 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 6 Prepare commissionSplitter - SetMoCToken
+    // STEP 6 Prepare MoCInrate - setCommissionRateByTxType
 
     step = 6;
-    targetBatch = await batchChanger.targetsToExecute(step);
-    dataBatch = await batchChanger.datasToExecute(step);
-
-    target = config.proxyAddresses.CommissionSplitter;
-    const commissionSplitter = await CommissionSplitter.at(target);
-
-    encodeData = commissionSplitter.contract.methods
-      .setMocToken(config.implementationAddresses.MoCToken)
-      .encodeABI();
-
-    if (dataBatch === encodeData && target === targetBatch) {
-      console.log(
-        `OK! STEP ${step}. Prepare commissionSplitter.sol execute: [setMocToken(${config.implementationAddresses.MoCToken})]`
-      );
-    } else {
-      msjError = `ERROR! NOT VALID! STEP: ${step}.`;
-      console.log(msjError);
-      error.push(msjError);
-    }
-
-    // STEP 7 Prepare commissionSplitter - mocTokenCommissionsAddress
-
-    step = 7;
-    targetBatch = await batchChanger.targetsToExecute(step);
-    dataBatch = await batchChanger.datasToExecute(step);
-
-    target = config.proxyAddresses.CommissionSplitter;
-
-    encodeData = commissionSplitter.contract.methods
-      .setMocTokenCommissionAddress(config.valuesToAssign.mocTokenCommissionsAddress)
-      .encodeABI();
-
-    if (dataBatch === encodeData && target === targetBatch) {
-      console.log(
-        `OK! STEP ${step}. Prepare commissionSplitter.sol execute: [setMocTokenCommissionAddress(${config.valuesToAssign.mocTokenCommissionsAddress})]`
-      );
-    } else {
-      msjError = `ERROR! NOT VALID! STEP: ${step}.`;
-      console.log(msjError);
-      error.push(msjError);
-    }
-
-    // STEP 8 Prepare MoCInrate - setCommissionRateByTxType
-
-    step = 8;
-    let varStep = 8;
+    let varStep = 6;
 
     target = config.proxyAddresses.MoCInrate;
     const moCInrate = await MoCInrate.at(target);
@@ -330,20 +285,20 @@ module.exports = async callback => {
       varStep += 1;
     }
 
-    // STEP 20 Prepare MoCInrate - setMocTokenCommissionAddress
-    step = 20;
+    // STEP 18 Prepare MoCInrate - setCommissionsAddress
+    step = 18;
     target = config.proxyAddresses.MoCInrate;
 
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 
     encodeData = moCInrate.contract.methods
-      .setCommissionsAddress(config.implementationAddresses.CommissionSplitter)
+      .setCommissionsAddress(config.proxyAddresses.CommissionSplitter)
       .encodeABI();
 
     if (dataBatch === encodeData && target === targetBatch) {
       console.log(
-        `OK! STEP ${step}. Prepare MoCInrate.sol execute: [setMocTokenCommissionAddress(${config.implementationAddresses.CommissionSplitter})]`
+        `OK! STEP ${step}. Prepare MoCInrate.sol execute: [setCommissionsAddress(${config.proxyAddresses.CommissionSplitter})]`
       );
     } else {
       msjError = `ERROR! NOT VALID! STEP: ${step}.`;
@@ -351,9 +306,9 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 21 Prepare MoCState - setMoCPriceProvider
+    // STEP 19 Prepare MoCState - setMoCPriceProvider
 
-    step = 21;
+    step = 19;
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 
@@ -373,9 +328,9 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 22 Prepare MoCState - setMoCToken
+    // STEP 20 Prepare MoCState - setMoCToken
 
-    step = 22;
+    step = 20;
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 
@@ -394,9 +349,9 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 23 Prepare MoCState - setMoCVendors
+    // STEP 21 Prepare MoCState - setMoCVendors
 
-    step = 23;
+    step = 21;
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 
@@ -415,9 +370,9 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 24 Prepare MoCState - setLiquidationEnabled
+    // STEP 22 Prepare MoCState - setLiquidationEnabled
 
-    step = 24;
+    step = 22;
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 
@@ -436,9 +391,9 @@ module.exports = async callback => {
       error.push(msjError);
     }
 
-    // STEP 25 Prepare MoCState - setProtected
+    // STEP 23 Prepare MoCState - setProtected
 
-    step = 25;
+    step = 23;
     targetBatch = await batchChanger.targetsToExecute(step);
     dataBatch = await batchChanger.datasToExecute(step);
 

--- a/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha-original.json
+++ b/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha-original.json
@@ -7,7 +7,7 @@
     "MoCInrate": "0x2B57fb820601655ca7Da16a5134db4780Aa93E74",
     "MoCState": "0xB80C23576053A1a5278C1a43DC8471F432f77245",
     "MoCVendors": "",
-    "CommissionSplitter": "0xE79fE1d8D321d01aA973E319112Fb98eA319B7a1"
+    "CommissionSplitter": ""
   },
   "implementationAddresses": {
     "MoC": "",
@@ -23,7 +23,8 @@
     "MoCPriceProvider": "0xE972c8E83A5b97bB4FC867855A0aA13EF96f228D",
     "MoCVendors": "",
     "MoCHelperLib": "",
-    "CommissionSplitter": ""
+    "CommissionSplitter": "",
+    "MocReserve": "0x19F64674D8A5B4E652319F5e239eFd3bc969A1fE"
   },
   "valuesToAssign": {
     "commissionRates": {
@@ -43,7 +44,9 @@
     "liquidationEnabled": false,
     "protected": "1.5",
     "vendorGuardianAddress": "0xab242e50e95c2f539242763a4ed5db1aee5ce461",
-    "mocTokenCommissionsAddress": "0xb998C3Da8D24295406d308ea42c85c8acDa880Ba"
+    "mocTokenCommissionsAddress": "0xb998C3Da8D24295406d308ea42c85c8acDa880Ba",
+    "targetAddressCommissionPayment": "0x30d4433fF09757D33fFf99Cbe49C6384463bF551",
+    "mocProportion": "500000000000000000"
   },
   "changerAddresses": {
     "BatchChanger": ""

--- a/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha.json
+++ b/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha.json
@@ -49,7 +49,7 @@
     "mocProportion": "500000000000000000"
   },
   "changerAddresses": {
-    "BatchChanger": "0x7a21385861dC04aa1D26f346D285eb1eD2178d5B"
+    "BatchChanger": "0x64FF966aEaB340976c9B0Be27FF09203B377CaC2"
   },
   "governorOwnerAddress": "0xf69287F5Ca3cC3C6d3981f2412109110cB8af076"
 }

--- a/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha.json
+++ b/scripts/deploy/upgrade_v0.1.12/deployConfig-rdocTestnetAlpha.json
@@ -7,7 +7,7 @@
     "MoCInrate": "0x2B57fb820601655ca7Da16a5134db4780Aa93E74",
     "MoCState": "0xB80C23576053A1a5278C1a43DC8471F432f77245",
     "MoCVendors": "0xd282f98475A6996E1E0325BEa4ADe201Eb4c33B5",
-    "CommissionSplitter": "0xE79fE1d8D321d01aA973E319112Fb98eA319B7a1"
+    "CommissionSplitter": "0xE379f66A1Ec08f93b7F78Ebe34873bE0c2D9ac49"
   },
   "implementationAddresses": {
     "MoC": "0x004e56bE14f7356CA26340a32Ef9a3dD45f244B1",
@@ -23,7 +23,8 @@
     "MoCPriceProvider": "0xE972c8E83A5b97bB4FC867855A0aA13EF96f228D",
     "MoCVendors": "0xCFB0f6BDD16d5Cfa0AD723bF04776bD502500d4B",
     "MoCHelperLib": "0x5A4107D39EE333C729229c8050804BfC697e0Dc4",
-    "CommissionSplitter": "0xB7E7e5d032C0baC4d74862BC56fAbf429B608Db6"
+    "CommissionSplitter": "0x6bc766a4D93bA2fc2507103B5E42EdFe6e395a10",
+    "MocReserve": "0x19F64674D8A5B4E652319F5e239eFd3bc969A1fE"
   },
   "valuesToAssign": {
     "commissionRates": {
@@ -43,10 +44,12 @@
     "liquidationEnabled": false,
     "protected": "1.5",
     "vendorGuardianAddress": "0xab242e50e95c2f539242763a4ed5db1aee5ce461",
-    "mocTokenCommissionsAddress": "0xb998C3Da8D24295406d308ea42c85c8acDa880Ba"
+    "mocTokenCommissionsAddress": "0xb998C3Da8D24295406d308ea42c85c8acDa880Ba",
+    "targetAddressCommissionPayment": "0x30d4433fF09757D33fFf99Cbe49C6384463bF551",
+    "mocProportion": "500000000000000000"
   },
   "changerAddresses": {
-    "BatchChanger": "0x64D1fc6Af85A3B0d42c9c233337cb1B82b399d13"
+    "BatchChanger": "0x7a21385861dC04aa1D26f346D285eb1eD2178d5B"
   },
   "governorOwnerAddress": "0xf69287F5Ca3cC3C6d3981f2412109110cB8af076"
 }


### PR DESCRIPTION
… as a new contract not need a changer.

Fix using proxy address of commission splitter instead of implementation.

Settings need it for deployments.